### PR TITLE
fix: MultipartWriter method borrow issue

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -24,7 +24,7 @@ impl MultipartWriter {
         }
     }
 
-    pub fn add(mut self, mut reader: impl Read, headers: &str) -> io::Result<u64> {
+    pub fn add(&mut self, mut reader: impl Read, headers: &str) -> io::Result<u64> {
         // writer for our buffer
         let mut writer = std::io::BufWriter::new(&mut self.data);
 
@@ -51,7 +51,7 @@ impl MultipartWriter {
         io::copy(&mut reader, &mut writer)
     }
 
-    pub fn finish(mut self) {
+    pub fn finish(&mut self) {
         // writer for our buffer
         let mut writer = std::io::BufWriter::new(&mut self.data);
 


### PR DESCRIPTION
In `MultipartWriter` part, the `add()` and `finish()` should have `self` mutably borrowed.
Maybe a test will be helpful for this mod.